### PR TITLE
Switching to Splunk's fork of ort

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,15 +4,11 @@
 
 version: 2
 updates:
-  # Keep package.json (& lockfiles) up to date as soon as
-  # new versions are published to the npm registry
   - package-ecosystem: "gitsubmodule"
     directory: "/"
     schedule:
       interval: "daily"
-  # Keep Dockerfile up to date, batching pull requests weekly
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      # Check for updates to GitHub Actions every weekday
       interval: "daily"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
         with:
           submodules: recursive
           persist-credentials: false
+      - uses: actions/setup-node@v2
+        with:
+          node-version: '14'
       - name: Install yq
         run: sudo snap install yq
       - name: Set up QEMU

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ort"]
 	path = ort
-	url = https://github.com/arys-splunk/ort.git
+	url = https://github.com/splunk/ort.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "ort"]
 	path = ort
-	url = https://github.com/rfaircloth-splunk/ort.git
+	url = https://github.com/arys-splunk/ort.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -41,9 +41,9 @@ RUN pip3.9 install --user pipx; python3.9 -m pipx install pipenv
 # This seems to be fixing 
 # `pip install fails with "No such file or directory: 'c++': 'c++'"`
 # error when trying to install `grpcio` library.
-RUN python3.7 -m pip install --upgrade pip \
-    python3.8 -m pip install --upgrade pip \
-    python3.9 -m pip install --upgrade pip
+RUN python3.7 -m pip install --upgrade pip
+RUN python3.8 -m pip install --upgrade pip
+RUN python3.9 -m pip install --upgrade pip
 
 COPY entrypoint.sh /entrypoint.sh
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,14 +37,6 @@ RUN pip3.7 install pip==18.0 pipdeptree==0.13.2 virtualenv==20.2.2 pipenv poetry
 RUN pip3.8 install pip==18.0 pipdeptree==0.13.2 virtualenv==20.2.2 pipenv poetry
 RUN pip3.9 install --user pipx; python3.9 -m pipx install pipenv
 
-# Upgrade pip version for each Python version.
-# This seems to be fixing 
-# `pip install fails with "No such file or directory: 'c++': 'c++'"`
-# error when trying to install `grpcio` library.
-RUN python3.7 -m pip install --upgrade pip
-RUN python3.8 -m pip install --upgrade pip
-RUN python3.9 -m pip install --upgrade pip
-
 COPY entrypoint.sh /entrypoint.sh
 
 COPY custom root/.ort

--- a/LICENSE
+++ b/LICENSE
@@ -186,7 +186,7 @@
       same "printed page" as the copyright notice for easier
       identification within third-party archives.
 
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2021 Splunk Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 This action scans a project for third party components and reports the results. This action contains a curation file managed by Splunk Inc. Source is provided for this action however it may not be useful outside of our organization.
 
+[Forked version](https://github.com/splunk/ort) of `ort` is being used. The only difference is this [commit](https://github.com/splunk/ort/commit/78a98b8811fb4051dc18010bdda1bf09075bdf37) which assumes that the repository's it is scanning is Python 3 and will not fallback to Python 2 in case of any errors.
 
 # v1
-
-This release adds reliability for pulling node distributions from a cache of node releases.
 
 ```yaml
 steps:
@@ -20,8 +19,6 @@ steps:
         name: analysis
         path: .ort/
 ```
-
-The action will check tests/knowledge/* for potentialy identifying data and update the build or pr with annotations identifying violations.
 
 # License
 

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ name: "Addon Factory ORT Addon"
 description: "Produce third party component reports"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/addonfactory-ort-action:v1.5.8-develop.1"
+  image: "docker://ghcr.io/splunk/addonfactory-ort-action:v1.5.8-develop.2"
 inputs:
   args:
     description: Additional arguments to the scanner

--- a/action.yml
+++ b/action.yml
@@ -18,7 +18,7 @@ name: "Addon Factory ORT Addon"
 description: "Produce third party component reports"
 runs:
   using: "docker"
-  image: "docker://ghcr.io/splunk/addonfactory-ort-action:v1.5.7"
+  image: "docker://ghcr.io/splunk/addonfactory-ort-action:v1.5.8-develop.1"
 inputs:
   args:
     description: Additional arguments to the scanner


### PR DESCRIPTION
This PR switches `addonfactory-ort-action` to the Splunk's version of ort tool which is now described in the README.md as well.

I've tested this version with Google Workspace add-on and it is passing CI, but still `grpcio` is failing to install - I created a known issue for that (https://github.com/splunk/addonfactory-ort-action/issues/12). It should automatically fix when `ort` will update to the latest versions of `pip`.